### PR TITLE
Another attempt at fixing the setImmediate() issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@leosingleton/commonlibs",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -581,12 +581,6 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "11.13.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.6.tgz",
-      "integrity": "sha512-Xoo/EBzEe8HxTSwaZNLZjaW6M6tA/+GmD3/DZ6uo8qSaolE/9Oarko0oV1fVfrLqOz0tx0nXJB4rdD5c+vixLw==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leosingleton/commonlibs",
-  "version": "1.0.0-alpha.17",
+  "version": "1.0.0-alpha.18",
   "author": "Leo C. Singleton IV <leo@leosingleton.com>",
   "description": "Common Libraries for TypeScript and .NET Core",
   "homepage": "https://github.com/leosingleton/commonlibs-ts",
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@types/jasmine": "^2.5.52",
     "@types/jest": "^24.0.11",
-    "@types/node": "^11.13.6",
     "jasmine-core": "^3.4.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
@@ -26,9 +25,6 @@
     "typescript": "^3.4.4",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.0"
-  },
-  "dependencies": {
-    "setimmediate": "^1.0.5"
   },
   "scripts": {
     "build": "npx webpack --mode=none",


### PR DESCRIPTION
It appears the problem is in a polyfill that Webpack automatically
includes when it sees use of the setImmediate() function. This makes
setImmediate() work on a web page, but completely breaks web workers
on load, even if they don't actually call setImmediate().

Trying the slower workaround of setTimeout() in these cases.